### PR TITLE
Backward compatible support for JSqueeze 1.0 and 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "php": ">=5.4.0",
         "meenie/javascript-packer": "1.1",
         "linkorb/jsmin-php": "1.0.0",
-        "patchwork/jsqueeze": "v1.0"
+        "patchwork/jsqueeze": "~1.0|~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "e78875039d9daa1e3c20af389f1e408a",
+    "hash": "cf66dc46fa5ea1784501845ee46e802b",
+    "content-hash": "ee5633e074f3d8b67e4ce0905108acaa",
     "packages": [
         {
             "name": "linkorb/jsmin-php",
@@ -102,25 +103,30 @@
         },
         {
             "name": "patchwork/jsqueeze",
-            "version": "v1.0",
+            "version": "v2.0.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/nicolas-grekas/JSqueeze.git",
-                "reference": "4d75272c6316ab70c281afd863a7b6c2dc5446dd"
+                "url": "https://github.com/tchwork/jsqueeze.git",
+                "reference": "074a7ac403d1fae262fd662c43c04b62d71c3e50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nicolas-grekas/JSqueeze/zipball/4d75272c6316ab70c281afd863a7b6c2dc5446dd",
-                "reference": "4d75272c6316ab70c281afd863a7b6c2dc5446dd",
+                "url": "https://api.github.com/repos/tchwork/jsqueeze/zipball/074a7ac403d1fae262fd662c43c04b62d71c3e50",
+                "reference": "074a7ac403d1fae262fd662c43c04b62d71c3e50",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.1.4"
+                "php": ">=5.3.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
-                "psr-0": {
-                    "JSqueeze": "class/"
+                "psr-4": {
+                    "Patchwork\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -130,18 +136,17 @@
             "authors": [
                 {
                     "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com",
-                    "role": "Developer"
+                    "email": "p@tchwork.com"
                 }
             ],
             "description": "Efficient JavaScript minification in PHP",
-            "homepage": "https://github.com/nicolas-grekas/JSqueeze",
+            "homepage": "https://github.com/tchwork/jsqueeze",
             "keywords": [
                 "compression",
                 "javascript",
                 "minification"
             ],
-            "time": "2014-01-28 08:41:24"
+            "time": "2015-08-20 11:07:02"
         }
     ],
     "packages-dev": [
@@ -600,16 +605,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.9",
+            "version": "4.8.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "73fad41adb5b7bc3a494bb930d90648df1d5e74b"
+                "reference": "463163747474815c5ccd4ae12b5b355ec12158e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/73fad41adb5b7bc3a494bb930d90648df1d5e74b",
-                "reference": "73fad41adb5b7bc3a494bb930d90648df1d5e74b",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/463163747474815c5ccd4ae12b5b355ec12158e8",
+                "reference": "463163747474815c5ccd4ae12b5b355ec12158e8",
                 "shasum": ""
             },
             "require": {
@@ -668,20 +673,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-09-20 12:56:44"
+            "time": "2015-10-01 09:14:30"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.7",
+            "version": "2.3.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "5e2645ad49d196e020b85598d7c97e482725786a"
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/5e2645ad49d196e020b85598d7c97e482725786a",
-                "reference": "5e2645ad49d196e020b85598d7c97e482725786a",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
                 "shasum": ""
             },
             "require": {
@@ -724,7 +729,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-08-19 09:14:08"
+            "time": "2015-10-02 06:51:40"
         },
         {
             "name": "sebastian/comparator",

--- a/src/Compressor/JSqueezeCompressor.php
+++ b/src/Compressor/JSqueezeCompressor.php
@@ -22,7 +22,14 @@ class JSqueezeCompressor extends Compressor
      */
     protected function execute($string)
     {
-        $parser = new \JSqueeze();
+        // Try version 2.0 namespace first
+        $class = '\Patchwork\JSqueeze';
+        if (!class_exists($class)) {
+            // Otherwise use 1.0
+            $class = '\JSqueeze';
+        }
+        /** @var \Patchwork\JSqueeze|\JSqueeze $parser */
+        $parser = new $class();
         return $parser->squeeze($string);
     }
 }


### PR DESCRIPTION
Using HtmlCompress did not allow me to use the newest version of jsqueeze. If other people rely on version 1.0, this will still work. Otherwise 2.0 will be used automatically.

Edit: I updated `composer.lock` in the process and tests still pass. I hope you don't mind.