### PR TITLE
Minify CSS in style tags

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.4.0",
         "meenie/javascript-packer": "1.1",
         "linkorb/jsmin-php": "1.0.0",
-        "patchwork/jsqueeze": "~1.0|~2.0"
+        "patchwork/jsqueeze": "~1.0|~2.0",
+        "natxet/CssMin": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "meenie/javascript-packer": "1.1",
         "linkorb/jsmin-php": "1.0.0",
         "patchwork/jsqueeze": "~1.0|~2.0",
-        "natxet/CssMin": "^3.0"
+        "natxet/CssMin": "^3.0",
+        "websharks/css-minifier": "150820"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cf66dc46fa5ea1784501845ee46e802b",
-    "content-hash": "ee5633e074f3d8b67e4ce0905108acaa",
+    "hash": "04ec6a55d75b042575fc4fa54e5963fc",
+    "content-hash": "84823cb2101450697935749eabe4b893",
     "packages": [
         {
             "name": "linkorb/jsmin-php",
@@ -100,6 +100,53 @@
                 "javascript packer"
             ],
             "time": "2013-03-25 21:54:33"
+        },
+        {
+            "name": "natxet/CssMin",
+            "version": "v3.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/natxet/CssMin.git",
+                "reference": "92de3fe3ccb4f8298d31952490ef7d5395855c39"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/natxet/CssMin/zipball/92de3fe3ccb4f8298d31952490ef7d5395855c39",
+                "reference": "92de3fe3ccb4f8298d31952490ef7d5395855c39",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joe Scylla",
+                    "email": "joe.scylla@gmail.com",
+                    "homepage": "https://profiles.google.com/joe.scylla"
+                }
+            ],
+            "description": "Minifying CSS",
+            "homepage": "http://code.google.com/p/cssmin/",
+            "keywords": [
+                "css",
+                "minify"
+            ],
+            "time": "2015-09-25 11:13:11"
         },
         {
             "name": "patchwork/jsqueeze",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "04ec6a55d75b042575fc4fa54e5963fc",
-    "content-hash": "84823cb2101450697935749eabe4b893",
+    "hash": "4c81589f98d27dc8c9494fce6c1a103a",
+    "content-hash": "fa6b2decca0f3c05e5e8d0983c6c9718",
     "packages": [
         {
             "name": "linkorb/jsmin-php",
@@ -194,6 +194,60 @@
                 "minification"
             ],
             "time": "2015-08-20 11:07:02"
+        },
+        {
+            "name": "websharks/css-minifier",
+            "version": "150820",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/websharks/css-minifier.git",
+                "reference": "da1d0254c41e1f59c7337aa444d743e6056046ff"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/websharks/css-minifier/zipball/da1d0254c41e1f59c7337aa444d743e6056046ff",
+                "reference": "da1d0254c41e1f59c7337aa444d743e6056046ff",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "WebSharks\\CssMinifier\\": "src/includes/classes"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0+"
+            ],
+            "authors": [
+                {
+                    "name": "websharks",
+                    "homepage": "http://websharks-inc.com/",
+                    "role": "company"
+                },
+                {
+                    "name": "jaswsinc",
+                    "homepage": "http://jaswsinc.com/",
+                    "role": "developer"
+                },
+                {
+                    "name": "raamdev",
+                    "homepage": "http://raam.org/",
+                    "role": "developer"
+                }
+            ],
+            "description": "Compresses CSS.",
+            "homepage": "https://github.com/websharks/css-minifier",
+            "keywords": [
+                "compressor",
+                "css",
+                "websharks"
+            ],
+            "time": "2015-08-21 03:19:25"
         }
     ],
     "packages-dev": [

--- a/src/Compressor/CssMinCompressor.php
+++ b/src/Compressor/CssMinCompressor.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace WyriHaximus\HtmlCompress\Compressor;
+
+/**
+ * CssMinCompressor
+ *
+ * @author Marcel Voigt <mv@noch.so>
+ */
+class CssMinCompressor extends Compressor
+{
+    private $cssMin;
+
+    function __construct()
+    {
+        $this->cssMin = new \CssMin();
+    }
+
+    protected function execute($string)
+    {
+        return $this->cssMin->minify($string);
+    }
+}

--- a/src/Compressor/CssMinCompressor.php
+++ b/src/Compressor/CssMinCompressor.php
@@ -18,6 +18,27 @@ class CssMinCompressor extends Compressor
 
     protected function execute($string)
     {
+        // If there's no selector, this must be an inline CSS attribute
+        if (strlen($string) > 0 && strpos($string, '{') === false) {
+            return $this->minifyInline($string);
+        }
+
         return $this->cssMin->minify($string);
+    }
+
+    /**
+     * Minifies inline CSS attributes.
+     *
+     * @param string $string
+     *
+     * @return string
+     */
+    private function minifyInline($string)
+    {
+        // Get CssMin to compress inline CSS by adding and stripping a selector
+        $mock = 'body{' . $string . '}';
+        $minified = $this->execute($mock);
+
+        return substr($minified, 5, -1);
     }
 }

--- a/src/Compressor/CssMinifierCompressor.php
+++ b/src/Compressor/CssMinifierCompressor.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace WyriHaximus\HtmlCompress\Compressor;
+
+use WebSharks\CssMinifier\Core;
+
+/**
+ * CssMinifierCompressor
+ *
+ * @author Marcel Voigt <mv@noch.so>
+ */
+class CssMinifierCompressor extends Compressor
+{
+    protected function execute($string)
+    {
+        return Core::compress($string);
+    }
+}

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,6 +11,7 @@
 namespace WyriHaximus\HtmlCompress;
 
 use WyriHaximus\HtmlCompress\Compressor\BestResultCompressor;
+use WyriHaximus\HtmlCompress\Compressor\CssMinCompressor;
 use WyriHaximus\HtmlCompress\Compressor\JSqueezeCompressor;
 use WyriHaximus\HtmlCompress\Compressor\JSMinCompressor;
 use WyriHaximus\HtmlCompress\Compressor\JavaScriptPackerCompressor;
@@ -70,11 +71,16 @@ class Factory
                     [
                         'patterns' => [
                             Patterns::MATCH_SCRIPT,
-                            Patterns::MATCH_STYLE,
                             Patterns::MATCH_PRE,
                             Patterns::MATCH_TEXTAREA,
                         ],
                         'compressor' => new ReturnCompressor(),
+                    ],
+                    [
+                        'patterns' => [
+                            Patterns::MATCH_STYLE,
+                        ],
+                        'compressor' => new CssMinCompressor(),
                     ],
                 ],
             ]
@@ -111,11 +117,16 @@ class Factory
                     [
                         'patterns' => [
                             Patterns::MATCH_SCRIPT,
-                            Patterns::MATCH_STYLE,
                             Patterns::MATCH_PRE,
                             Patterns::MATCH_TEXTAREA,
                         ],
                         'compressor' => new ReturnCompressor(),
+                    ],
+                    [
+                        'patterns' => [
+                            Patterns::MATCH_STYLE,
+                        ],
+                        'compressor' => new CssMinCompressor(),
                     ],
                 ],
             ]

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -12,6 +12,7 @@ namespace WyriHaximus\HtmlCompress;
 
 use WyriHaximus\HtmlCompress\Compressor\BestResultCompressor;
 use WyriHaximus\HtmlCompress\Compressor\CssMinCompressor;
+use WyriHaximus\HtmlCompress\Compressor\CssMinifierCompressor;
 use WyriHaximus\HtmlCompress\Compressor\JSqueezeCompressor;
 use WyriHaximus\HtmlCompress\Compressor\JSMinCompressor;
 use WyriHaximus\HtmlCompress\Compressor\JavaScriptPackerCompressor;
@@ -128,7 +129,13 @@ class Factory
                             Patterns::MATCH_STYLE,
                             Patterns::MATCH_STYLE_INLINE,
                         ],
-                        'compressor' => new CssMinCompressor(),
+                        'compressor' => new BestResultCompressor(
+                            [
+                                new CssMinCompressor(),
+                                new CssMinifierCompressor(),
+                                new ReturnCompressor(),
+                            ]
+                        ),
                     ],
                 ],
             ]

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -79,6 +79,7 @@ class Factory
                     [
                         'patterns' => [
                             Patterns::MATCH_STYLE,
+                            Patterns::MATCH_STYLE_INLINE,
                         ],
                         'compressor' => new CssMinCompressor(),
                     ],
@@ -125,6 +126,7 @@ class Factory
                     [
                         'patterns' => [
                             Patterns::MATCH_STYLE,
+                            Patterns::MATCH_STYLE_INLINE,
                         ],
                         'compressor' => new CssMinCompressor(),
                     ],

--- a/src/Patterns.php
+++ b/src/Patterns.php
@@ -20,7 +20,7 @@ class Patterns
     const MATCH_PRE          = '!(<pre>|<pre[^>]*>?)(.*?)(</pre>)!is';
     const MATCH_TEXTAREA     = '!(<textarea>|<textarea[^>]*>?)(.*?)(</textarea>)!is';
     const MATCH_STYLE        = '!(<style>|<style[^>]*>?)(.*?)(</style>)!is';
-    const MATCH_STYLE_INLINE = '!(<[^>]* style=">)(.*?)(")!is';
+    const MATCH_STYLE_INLINE = '!(<[^>]* style=")(.*?)(")!is';
     // @codingStandardsIgnoreStart
     const MATCH_JSCRIPT      = '!(<script>|<script[^>]*type="text/javascript"[^>]*>|<script[^>]*type=\'text/javascript\'[^>]*>)(.*?)(</script>)!is';
     // @codingStandardsIgnoreEnd

--- a/src/Patterns.php
+++ b/src/Patterns.php
@@ -17,12 +17,13 @@ namespace WyriHaximus\HtmlCompress;
  */
 class Patterns
 {
-    const MATCH_PRE        = '!(<pre>|<pre[^>]*>?)(.*?)(</pre>)!is';
-    const MATCH_TEXTAREA   = '!(<textarea>|<textarea[^>]*>?)(.*?)(</textarea>)!is';
-    const MATCH_STYLE      = '!(<style>|<style[^>]*>?)(.*?)(</style>)!is';
+    const MATCH_PRE          = '!(<pre>|<pre[^>]*>?)(.*?)(</pre>)!is';
+    const MATCH_TEXTAREA     = '!(<textarea>|<textarea[^>]*>?)(.*?)(</textarea>)!is';
+    const MATCH_STYLE        = '!(<style>|<style[^>]*>?)(.*?)(</style>)!is';
+    const MATCH_STYLE_INLINE = '!(<[^>]* style=">)(.*?)(")!is';
     // @codingStandardsIgnoreStart
-    const MATCH_JSCRIPT    = '!(<script>|<script[^>]*type="text/javascript"[^>]*>|<script[^>]*type=\'text/javascript\'[^>]*>)(.*?)(</script>)!is';
+    const MATCH_JSCRIPT      = '!(<script>|<script[^>]*type="text/javascript"[^>]*>|<script[^>]*type=\'text/javascript\'[^>]*>)(.*?)(</script>)!is';
     // @codingStandardsIgnoreEnd
-    const MATCH_SCRIPT     = '!(<script[^>]*>?)(.*?)(</script>)!is';
-    const MATCH_NOCOMPRESS = '!(<nocompress>)(.*?)(</nocompress>)!is';
+    const MATCH_SCRIPT       = '!(<script[^>]*>?)(.*?)(</script>)!is';
+    const MATCH_NOCOMPRESS   = '!(<nocompress>)(.*?)(</nocompress>)!is';
 }

--- a/tests/Compressor/AbstractVendorCompressorTest.php
+++ b/tests/Compressor/AbstractVendorCompressorTest.php
@@ -10,10 +10,32 @@
  */
 namespace WyriHaximus\HtmlCompress\Tests\Compressor;
 
+use WyriHaximus\HtmlCompress\Compressor\CompressorInterface;
+
 abstract class AbstractVendorCompressorTest extends \PHPUnit_Framework_TestCase {
 
-    public function testCompress() {
+    /**
+     * @var CompressorInterface
+     */
+    protected $compressor;
+
+    /**
+     * Compressor class to instantiate $compressor
+     */
+    const COMPRESSOR = '';
+
+    protected function setUp()
+    {
         $compressor = static::COMPRESSOR;
-        $this->assertTrue(is_string((new $compressor)->compress('foo ')));
+        $this->compressor = new $compressor();
+    }
+
+    protected function tearDown()
+    {
+        $this->compressor = null;
+    }
+
+    public function testCompress() {
+        $this->assertTrue(is_string($this->compressor->compress('foo ')));
     }
 }

--- a/tests/Compressor/CssMinCompressorTest.php
+++ b/tests/Compressor/CssMinCompressorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace WyriHaximus\HtmlCompress\Tests\Compressor;
+
+use WyriHaximus\HtmlCompress\Compressor\CssMinCompressor;
+
+class CssMinCompressorTest extends AbstractVendorCompressorTest {
+
+    const COMPRESSOR = 'WyriHaximus\HtmlCompress\Compressor\CssMinCompressor';
+
+    public function providerReturn() {
+        return [
+            [
+                'p { background-color: #ffffff; font-size: 1px; }',
+                'p{background-color:#ffffff;font-size:1px}',
+            ],
+            [
+                '/* comments */
+                p { background-color: #ffffff; font-size: 1px; }',
+                'p{background-color:#ffffff;font-size:1px}',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerReturn
+     */
+    public function testReturn($input, $expected) {
+        $actual = $this->compressor->compress($input);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Compressor/CssMinCompressorTest.php
+++ b/tests/Compressor/CssMinCompressorTest.php
@@ -1,14 +1,18 @@
 <?php
 
-namespace WyriHaximus\HtmlCompress\Tests\Compressor;
+namespace WyriHaximus\HtmlCompress\tests\Compressor;
 
-use WyriHaximus\HtmlCompress\Compressor\CssMinCompressor;
-
-class CssMinCompressorTest extends AbstractVendorCompressorTest {
-
+/**
+ * CssMinCompressorTest
+ *
+ * @author Marcel Voigt <mv@noch.so>
+ */
+class CssMinCompressorTest extends AbstractVendorCompressorTest
+{
     const COMPRESSOR = 'WyriHaximus\HtmlCompress\Compressor\CssMinCompressor';
 
-    public function providerReturn() {
+    public function providerReturn()
+    {
         return [
             [
                 'p { background-color: #ffffff; font-size: 1px; }',
@@ -19,14 +23,30 @@ class CssMinCompressorTest extends AbstractVendorCompressorTest {
                 p { background-color: #ffffff; font-size: 1px; }',
                 'p{background-color:#ffffff;font-size:1px}',
             ],
+            [
+                'background-color: #FFFFFF ; ',
+                'background-color:#FFFFFF',
+            ],
+            [
+                'background-color: #FFFFFF; font-size: 14px
+                ;
+                ',
+                'background-color:#FFFFFF;font-size:14px',
+            ],
         ];
     }
 
     /**
      * @dataProvider providerReturn
      */
-    public function testReturn($input, $expected) {
+    public function testReturn($input, $expected)
+    {
         $actual = $this->compressor->compress($input);
         $this->assertSame($expected, $actual);
+    }
+
+    public function testCompress()
+    {
+        $this->assertTrue(is_string($this->compressor->compress('background-color: red;')));
     }
 }

--- a/tests/Compressor/CssMinifierCompressorTest.php
+++ b/tests/Compressor/CssMinifierCompressorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WyriHaximus\HtmlCompress\Tests\Compressor;
+
+/**
+ * CssMinifierCompressorTest
+ *
+ * @author Marcel Voigt <mv@noch.so>
+ */
+class CssMinifierCompressorTest extends AbstractVendorCompressorTest
+{
+    const COMPRESSOR = 'WyriHaximus\HtmlCompress\Compressor\CssMinifierCompressor';
+
+    public function providerReturn()
+    {
+        return [
+            [
+                'p { background-color: #ffffff; font-size: 1px; }',
+                'p{background-color: #FFF;font-size: 1px}',
+            ],
+            [
+                '/* comments */
+                p { background-color: #ffffff; font-size: 1px; }',
+                'p{background-color: #FFF;font-size: 1px}',
+            ],
+            [
+                'background-color: #FFFFFF ; ',
+                'background-color: #FFF;',
+            ],
+            [
+                'background-color: #FFFFFF; font-size: 14px
+                ;
+                ',
+                'background-color: #FFF;font-size: 14px;',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerReturn
+     */
+    public function testReturn($input, $expected)
+    {
+        $actual = $this->compressor->compress($input);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/EdgeCases/blog.wyrihaximus.net/out.html
+++ b/tests/EdgeCases/blog.wyrihaximus.net/out.html
@@ -1,4 +1,1 @@
-<!DOCTYPE html><html><head><meta name="robots" content="noindex, follow"><style>
-        /** quick fix because bootstrap <pre> has a background-color. */
-        pre code { background-color: inherit; }
-    </style></head><body class="blog"><header><nav></nav></header><script>;window.jQuery||document.write('<script src="http://blog.wyrihaximus.net/components/jquery/jquery.min.js"><\/script>')</script></body></html>
+<!DOCTYPE html><html><head><meta name="robots" content="noindex, follow"><style>pre code{background-color:inherit}</style></head><body class="blog"><header><nav></nav></header><script>;window.jQuery||document.write('<script src="http://blog.wyrihaximus.net/components/jquery/jquery.min.js"><\/script>')</script></body></html>

--- a/tests/EdgeCases/inline-css/in.html
+++ b/tests/EdgeCases/inline-css/in.html
@@ -1,0 +1,3 @@
+<div style="margin: 0; padding: 0; display: inline;">
+
+</div>

--- a/tests/EdgeCases/inline-css/out.html
+++ b/tests/EdgeCases/inline-css/out.html
@@ -1,0 +1,1 @@
+<div style="margin:0;padding:0;display:inline"></div>


### PR DESCRIPTION
- Added CssMinCompressor using natxet/CssMin
- Improved AbstractVendorCompressorTest
  - setup() and tearDown() a protected $compressor for reuse of compressor
- Changed edge-case to reflect change
- Added test for CssMinProcessor
- Modified factories to minify CSS by default