### PR TITLE
Fix character encoding problem

### DIFF
--- a/src/Compressor/HtmlCompressor.php
+++ b/src/Compressor/HtmlCompressor.php
@@ -25,7 +25,7 @@ class HtmlCompressor extends Compressor
         // Replace newlines, returns and tabs with spaces
         $string = str_replace(["\r", "\n", "\t"], ' ', $string);
         // Replace multiple spaces with a single space
-        $string = preg_replace('/(\s+)/m', ' ', $string);
+        $string = preg_replace('/(\s+)/mu', ' ', $string);
 
         // Remove spaces that are followed by either > or <
         $string = preg_replace('/ (>)/', '$1', $string);

--- a/tests/Compressor/HtmlCompressorTest.php
+++ b/tests/Compressor/HtmlCompressorTest.php
@@ -139,4 +139,22 @@ class HtmlCompressorTest extends \PHPUnit_Framework_TestCase {
         $actual = $this->compressor->compress($input);
         $this->assertSame($expected, $actual);
     }
+
+    public function providerSpecialCharacterEncoding() {
+        return [
+            [
+                "<html>\r\n\t<body>\xc3\xa0</body>\r\n\t</html>",
+                '<html><body>à</body></html>',
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider providerSpecialCharacterEncoding
+     */
+    public function testSpecialCharacterEncoding($input, $expected) {
+        $actual = $this->compressor->compress($input);
+        $this->assertSame($expected, $actual);
+    }
+
 }


### PR DESCRIPTION
Hi, 

I had an issue with some unicode characters, "à" become after compression: 
![capture d ecran 2016-07-25 a 10 29 28](https://cloud.githubusercontent.com/assets/2526939/17094988/b107c284-5252-11e6-9a6f-ca1ebe3b9fa8.png)

This is a preg_replace problem, see: http://stackoverflow.com/questions/19629893/does-preg-replace-change-my-character-set

Let me know if I have to modify my PR. 

Cheers. 
