### PR TITLE
Enhance assertions

### DIFF
--- a/tests/Compressor/AbstractVendorCompressorTest.php
+++ b/tests/Compressor/AbstractVendorCompressorTest.php
@@ -30,6 +30,6 @@ abstract class AbstractVendorCompressorTest extends TestCase
 
     public function testCompress()
     {
-        $this->assertTrue(is_string($this->compressor->compress('foo ')));
+        $this->assertInternalType('string', $this->compressor->compress('foo '));
     }
 }

--- a/tests/Compressor/CssMinCompressorTest.php
+++ b/tests/Compressor/CssMinCompressorTest.php
@@ -51,6 +51,6 @@ final class CssMinCompressorTest extends AbstractVendorCompressorTest
 
     public function testCompress()
     {
-        $this->assertTrue(is_string($this->compressor->compress('background-color: red;')));
+        $this->assertInternalType('string', $this->compressor->compress('background-color: red;'));
     }
 }


### PR DESCRIPTION
# Changed log
- Using `assertInternalType` assertion to check whether the expected and result type are string.