### PR TITLE
Make HtmlMin injectable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,26 @@ composer require wyrihaximus/html-compress
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-$parser = \WyriHaximus\HtmlCompress\Factory::construct();
+$parser = Factory::constructSmallest();
 $compressedHtml = $parser->compress($sourceHtml);
 ```
+
+## Advanced Usage ##
+
+All factory methods come with a `WithHtmlMin` variant allowing you to set options on the underlying `HtmlMin` instance:
+
+```php
+<?php
+
+require dirname(__DIR__) . '/vendor/autoload.php';
+
+$htmlMin = new HtmlMin();
+$htmlMin->doRemoveHttpPrefixFromAttributes();
+$htmlMin->doMakeSameDomainsLinksRelative(['example.com']);
+
+$parser = Factory::constructSmallest()->withHtmlMin($htmlMin);
+$compressedHtml = $parser->compress($sourceHtml);
+``` 
 
 ## Integration ##
 

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     "require": {
         "php": "^7.4",
         "thecodingmachine/safe": "^1.1",
-        "voku/html-min": "^4.1",
-        "voku/simple_html_dom": "^4.7",
+        "voku/html-min": "^4.4.3",
+        "voku/simple_html_dom": "^4.7.17",
         "wyrihaximus/compress": "^1.1",
         "wyrihaximus/constants": "^1.5",
         "wyrihaximus/css-compress": "^1.0.1",
@@ -25,7 +25,7 @@
     },
     "require-dev": {
         "wyrihaximus/coding-standard": "^1.0",
-        "wyrihaximus/test-utilities": "^2.2"
+        "wyrihaximus/test-utilities": "^2.3"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21fba29f40247ca62c5b09a797453402",
+    "content-hash": "6768b96ae4039c9b341078014dbd818f",
     "packages": [
         {
             "name": "jalle19/php-yui-compressor",
@@ -323,7 +323,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v5.0.7",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -372,6 +372,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-27T16:56:45+00:00"
         },
         {
@@ -652,6 +666,20 @@
                 "html",
                 "minifier"
             ],
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                }
+            ],
             "time": "2020-04-06T21:26:16+00:00"
         },
         {
@@ -710,6 +738,24 @@
                 "HTML Parser",
                 "dom",
                 "php dom"
+            ],
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/moelleken",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/voku",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/voku",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/voku/simple_html_dom",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-09T21:20:43+00:00"
         },
@@ -955,16 +1001,16 @@
     "packages-dev": [
         {
             "name": "amphp/amp",
-            "version": "v2.4.3",
+            "version": "v2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/amphp/amp.git",
-                "reference": "23ac95fc6d6973231763f5ed7d1309b39429b974"
+                "reference": "1e58d53e4af390efc7813e36cd215bd82cba4b06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/amphp/amp/zipball/23ac95fc6d6973231763f5ed7d1309b39429b974",
-                "reference": "23ac95fc6d6973231763f5ed7d1309b39429b974",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/1e58d53e4af390efc7813e36cd215bd82cba4b06",
+                "reference": "1e58d53e4af390efc7813e36cd215bd82cba4b06",
                 "shasum": ""
             },
             "require": {
@@ -1029,7 +1075,7 @@
                 "non-blocking",
                 "promise"
             ],
-            "time": "2020-04-19T15:54:21+00:00"
+            "time": "2020-04-30T04:54:50+00:00"
         },
         {
             "name": "amphp/byte-stream",
@@ -1150,6 +1196,16 @@
                 "ssl",
                 "tls"
             ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-08T08:27:21+00:00"
         },
         {
@@ -1229,6 +1285,16 @@
                 "autoload",
                 "dependency",
                 "package"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-04-10T09:44:22+00:00"
         },
@@ -1394,6 +1460,12 @@
             "keywords": [
                 "Xdebug",
                 "performance"
+            ],
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                }
             ],
             "time": "2020-03-01T12:26:26+00:00"
         },
@@ -1582,41 +1654,42 @@
         },
         {
             "name": "ergebnis/composer-normalize",
-            "version": "2.3.2",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/composer-normalize.git",
-                "reference": "d171b088ff9dcfda53277200a9ecc9a1d0deaef5"
+                "reference": "6129311c1738bd45a06ed7c3773b631d75336f93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/d171b088ff9dcfda53277200a9ecc9a1d0deaef5",
-                "reference": "d171b088ff9dcfda53277200a9ecc9a1d0deaef5",
+                "url": "https://api.github.com/repos/ergebnis/composer-normalize/zipball/6129311c1738bd45a06ed7c3773b631d75336f93",
+                "reference": "6129311c1738bd45a06ed7c3773b631d75336f93",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1.0",
-                "ergebnis/json-normalizer": "~0.11.0",
+                "composer-plugin-api": "^1.1.0 || ^2.0.0",
+                "ergebnis/json-normalizer": "~0.12.0",
                 "ergebnis/json-printer": "^3.0.2",
                 "localheinz/diff": "^1.0.1",
                 "php": "^7.1"
             },
             "require-dev": {
-                "composer/composer": "^1.10.1",
+                "composer/composer": "^1.10.5",
+                "composer/package-versions-deprecated": "^1.8.0",
                 "ergebnis/license": "~0.1.0",
-                "ergebnis/php-cs-fixer-config": "^2.1.0",
-                "ergebnis/phpstan-rules": "~0.14.3",
+                "ergebnis/php-cs-fixer-config": "^2.1.2",
+                "ergebnis/phpstan-rules": "~0.14.4",
                 "ergebnis/test-util": "~1.0.0",
                 "jangregor/phpstan-prophecy": "~0.6.2",
-                "phpstan/extension-installer": "^1.0.3",
-                "phpstan/phpstan": "~0.12.14",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "~0.12.19",
                 "phpstan/phpstan-deprecation-rules": "~0.12.2",
-                "phpstan/phpstan-phpunit": "~0.12.6",
+                "phpstan/phpstan-phpunit": "~0.12.8",
                 "phpstan/phpstan-strict-rules": "~0.12.2",
                 "phpunit/phpunit": "^7.5.20",
-                "psalm/plugin-phpunit": "~0.9.0",
-                "symfony/filesystem": "^4.4.5",
-                "vimeo/psalm": "^3.9.5"
+                "psalm/plugin-phpunit": "~0.10.0",
+                "symfony/filesystem": "^4.4.7",
+                "vimeo/psalm": "^3.11.2"
             },
             "type": "composer-plugin",
             "extra": {
@@ -1645,20 +1718,38 @@
                 "normalizer",
                 "plugin"
             ],
-            "time": "2020-03-13T20:09:01+00:00"
+            "funding": [
+                {
+                    "url": "https://paypal.me/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.buymeacoffee.com/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-26T18:11:30+00:00"
         },
         {
             "name": "ergebnis/json-normalizer",
-            "version": "0.11.0",
+            "version": "0.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ergebnis/json-normalizer.git",
-                "reference": "6a41d9a53f640bff8ef5516efd3aadc6f1ad1f37"
+                "reference": "0197447cd5d8f7e82116e904196a3e9f470655db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/6a41d9a53f640bff8ef5516efd3aadc6f1ad1f37",
-                "reference": "6a41d9a53f640bff8ef5516efd3aadc6f1ad1f37",
+                "url": "https://api.github.com/repos/ergebnis/json-normalizer/zipball/0197447cd5d8f7e82116e904196a3e9f470655db",
+                "reference": "0197447cd5d8f7e82116e904196a3e9f470655db",
                 "shasum": ""
             },
             "require": {
@@ -1668,20 +1759,20 @@
                 "php": "^7.1"
             },
             "require-dev": {
-                "ergebnis/php-cs-fixer-config": "^1.1.3",
-                "ergebnis/phpstan-rules": "~0.14.2",
-                "ergebnis/test-util": "~0.9.1",
+                "ergebnis/license": "~0.1.0",
+                "ergebnis/php-cs-fixer-config": "^2.1.2",
+                "ergebnis/phpstan-rules": "~0.14.4",
+                "ergebnis/test-util": "~1.0.0",
                 "infection/infection": "~0.13.6",
-                "jangregor/phpstan-prophecy": "~0.6.0",
-                "phpbench/phpbench": "~0.16.10",
-                "phpstan/extension-installer": "^1.0.3",
-                "phpstan/phpstan": "~0.12.4",
-                "phpstan/phpstan-deprecation-rules": "~0.12.1",
-                "phpstan/phpstan-phpunit": "~0.12.5",
-                "phpstan/phpstan-strict-rules": "~0.12.1",
+                "jangregor/phpstan-prophecy": "~0.6.2",
+                "phpstan/extension-installer": "^1.0.4",
+                "phpstan/phpstan": "~0.12.18",
+                "phpstan/phpstan-deprecation-rules": "~0.12.2",
+                "phpstan/phpstan-phpunit": "~0.12.8",
+                "phpstan/phpstan-strict-rules": "~0.12.2",
                 "phpunit/phpunit": "^7.5.20",
-                "psalm/plugin-phpunit": "~0.8.0",
-                "vimeo/psalm": "^3.8.2"
+                "psalm/plugin-phpunit": "~0.10.0",
+                "vimeo/psalm": "^3.11.2"
             },
             "type": "library",
             "autoload": {
@@ -1705,7 +1796,25 @@
                 "json",
                 "normalizer"
             ],
-            "time": "2020-01-09T13:43:00+00:00"
+            "funding": [
+                {
+                    "url": "https://paypal.me/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.buymeacoffee.com/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-19T12:30:41+00:00"
         },
         {
             "name": "ergebnis/json-printer",
@@ -1827,6 +1936,24 @@
                 "PHPStan",
                 "phpstan-extreme-rules",
                 "phpstan-rules"
+            ],
+            "funding": [
+                {
+                    "url": "https://paypal.me/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.amazon.de/hz/wishlist/ls/2NCHMSJ4BC1OW",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.buymeacoffee.com/localheinz",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/localheinz",
+                    "type": "github"
+                }
             ],
             "time": "2020-03-13T20:00:07+00:00"
         },
@@ -2216,16 +2343,16 @@
         },
         {
             "name": "infection/infection",
-            "version": "0.16.2",
+            "version": "0.16.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/infection/infection.git",
-                "reference": "9a3bca95fa873fba4a4a37a5fd35c6d572c0f23b"
+                "reference": "52d597af80429d52dd6218fcb9766fc7653ec88c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/infection/infection/zipball/9a3bca95fa873fba4a4a37a5fd35c6d572c0f23b",
-                "reference": "9a3bca95fa873fba4a4a37a5fd35c6d572c0f23b",
+                "url": "https://api.github.com/repos/infection/infection/zipball/52d597af80429d52dd6218fcb9766fc7653ec88c",
+                "reference": "52d597af80429d52dd6218fcb9766fc7653ec88c",
                 "shasum": ""
             },
             "require": {
@@ -2319,7 +2446,7 @@
                 "testing",
                 "unit testing"
             ],
-            "time": "2020-04-08T18:56:58+00:00"
+            "time": "2020-04-26T11:15:23+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -2827,6 +2954,20 @@
                 "php",
                 "symfony"
             ],
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
             "time": "2020-04-04T19:56:08+00:00"
         },
         {
@@ -2878,6 +3019,16 @@
                 }
             ],
             "description": "Composer plugin that provides efficient querying for installed package versions (no runtime IO)",
+            "funding": [
+                {
+                    "url": "https://github.com/Ocramius",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/ocramius/package-versions",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-06T17:43:35+00:00"
         },
         {
@@ -3249,23 +3400,20 @@
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a"
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/63a995caa1ca9e5590304cd845c15ad6d482a62a",
-                "reference": "63a995caa1ca9e5590304cd845c15ad6d482a62a",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
+                "reference": "6568f4687e5b41b054365f9ae03fcb1ed5f2069b",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "~6"
             },
             "type": "library",
             "extra": {
@@ -3297,7 +3445,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2018-08-07T13:53:10+00:00"
+            "time": "2020-04-27T09:25:28+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -3598,6 +3746,20 @@
                 "MIT"
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-04-19T20:35:10+00:00"
         },
         {
@@ -3922,6 +4084,12 @@
                 "filesystem",
                 "iterator"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-18T05:02:12+00:00"
         },
         {
@@ -4070,6 +4238,12 @@
             "keywords": [
                 "timer"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
             "time": "2020-04-20T06:00:37+00:00"
         },
         {
@@ -4123,16 +4297,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.1.3",
+            "version": "9.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "a74780472172957a65cb5999a597e8c0878cf39c"
+                "reference": "2d7080c622cf7884992e7c3cf87853877bae8ff4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/a74780472172957a65cb5999a597e8c0878cf39c",
-                "reference": "a74780472172957a65cb5999a597e8c0878cf39c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2d7080c622cf7884992e7c3cf87853877bae8ff4",
+                "reference": "2d7080c622cf7884992e7c3cf87853877bae8ff4",
                 "shasum": ""
             },
             "require": {
@@ -4153,7 +4327,7 @@
                 "phpunit/php-invoker": "^3.0",
                 "phpunit/php-text-template": "^2.0",
                 "phpunit/php-timer": "^3.1.4",
-                "sebastian/code-unit": "^1.0",
+                "sebastian/code-unit": "^1.0.2",
                 "sebastian/comparator": "^4.0",
                 "sebastian/diff": "^4.0",
                 "sebastian/environment": "^5.0.1",
@@ -4207,7 +4381,17 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2020-04-23T04:42:05+00:00"
+            "funding": [
+                {
+                    "url": "https://phpunit.de/donate.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-30T06:32:53+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4414,16 +4598,16 @@
         },
         {
             "name": "sebastian/code-unit",
-            "version": "1.0.0",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "8d8f09bd47c75159921e6e84fdef146343962866"
+                "reference": "ac958085bc19fcd1d36425c781ef4cbb5b06e2a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/8d8f09bd47c75159921e6e84fdef146343962866",
-                "reference": "8d8f09bd47c75159921e6e84fdef146343962866",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/ac958085bc19fcd1d36425c781ef4cbb5b06e2a5",
+                "reference": "ac958085bc19fcd1d36425c781ef4cbb5b06e2a5",
                 "shasum": ""
             },
             "require": {
@@ -4456,7 +4640,13 @@
             ],
             "description": "Collection of value objects that represent the PHP code units",
             "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "time": "2020-03-30T11:59:20+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2020-04-30T05:58:10+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -4673,6 +4863,12 @@
                 "Xdebug",
                 "environment",
                 "hhvm"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
             ],
             "time": "2020-04-14T13:36:52+00:00"
         },
@@ -5078,20 +5274,20 @@
         },
         {
             "name": "seld/jsonlint",
-            "version": "1.7.2",
+            "version": "1.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/jsonlint.git",
-                "reference": "e2e5d290e4d2a4f0eb449f510071392e00e10d19"
+                "reference": "ff2aa5420bfbc296cf6a0bc785fa5b35736de7c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/e2e5d290e4d2a4f0eb449f510071392e00e10d19",
-                "reference": "e2e5d290e4d2a4f0eb449f510071392e00e10d19",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/ff2aa5420bfbc296cf6a0bc785fa5b35736de7c1",
+                "reference": "ff2aa5420bfbc296cf6a0bc785fa5b35736de7c1",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3 || ^7.0"
+                "php": "^5.3 || ^7.0 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
@@ -5123,7 +5319,17 @@
                 "parser",
                 "validator"
             ],
-            "time": "2019-10-24T14:27:39+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-30T19:05:18+00:00"
         },
         {
             "name": "seld/phar-utils",
@@ -5171,16 +5377,16 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "6.3.2",
+            "version": "6.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "6de1e23a949c4b026f6d92584d2f47841f740868"
+                "reference": "b905a82255749de847fd4de607c7a4c8163f058d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/6de1e23a949c4b026f6d92584d2f47841f740868",
-                "reference": "6de1e23a949c4b026f6d92584d2f47841f740868",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/b905a82255749de847fd4de607c7a4c8163f058d",
+                "reference": "b905a82255749de847fd4de607c7a4c8163f058d",
                 "shasum": ""
             },
             "require": {
@@ -5214,7 +5420,17 @@
                 "MIT"
             ],
             "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
-            "time": "2020-04-20T12:29:46+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-28T07:15:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5269,7 +5485,7 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.0.7",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
@@ -5341,20 +5557,34 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-30T11:42:42+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.0.7",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "ca3b87dd09fff9b771731637f5379965fbfab420"
+                "reference": "7cd0dafc4353a0f62e307df90b48466379c8cc91"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ca3b87dd09fff9b771731637f5379965fbfab420",
-                "reference": "ca3b87dd09fff9b771731637f5379965fbfab420",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/7cd0dafc4353a0f62e307df90b48466379c8cc91",
+                "reference": "7cd0dafc4353a0f62e307df90b48466379c8cc91",
                 "shasum": ""
             },
             "require": {
@@ -5391,11 +5621,25 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:56:45+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-12T14:40:17+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.4.7",
+            "version": "v4.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -5440,6 +5684,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-27T16:54:36+00:00"
         },
         {
@@ -5497,6 +5755,20 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-02-27T09:26:54+00:00"
         },
@@ -5557,6 +5829,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-03-09T19:04:49+00:00"
         },
         {
@@ -5615,20 +5901,34 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-02-27T09:26:54+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v5.0.7",
+            "version": "v5.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "c5ca4a0fc16a0c888067d43fbcfe1f8a53d8e70e"
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/c5ca4a0fc16a0c888067d43fbcfe1f8a53d8e70e",
-                "reference": "c5ca4a0fc16a0c888067d43fbcfe1f8a53d8e70e",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3179f68dff5bad14d38c4114a1dab98030801fd7",
+                "reference": "3179f68dff5bad14d38c4114a1dab98030801fd7",
                 "shasum": ""
             },
             "require": {
@@ -5664,7 +5964,21 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-27T16:56:45+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-15T15:59:10+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6260,5 +6574,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.4"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/infection.json.dist
+++ b/infection.json.dist
@@ -9,6 +9,18 @@
         "text": "infection-log.txt"
     },
     "mutators": {
-        "@default": true
+        "@default": true,
+        "MethodCallRemoval": {
+            "ignore": [
+                "WyriHaximus\\HtmlCompress\\Compressor\\HtmlCompressor::__construct",
+                "WyriHaximus\\HtmlCompress\\HtmlMinObserver::domElementBeforeMinification"
+            ]
+        },
+        "PublicVisibility": {
+            "ignore": [
+                "WyriHaximus\\HtmlCompress\\Patterns::add",
+                "WyriHaximus\\HtmlCompress\\Patterns::compress"
+            ]
+        }
     }
 }

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -2,6 +2,7 @@
 
 namespace WyriHaximus\HtmlCompress;
 
+use voku\helper\HtmlMin;
 use WyriHaximus\Compress\ReturnCompressor;
 use WyriHaximus\CssCompress\Factory as CssFactory;
 use WyriHaximus\HtmlCompress\Pattern\JavaScript;
@@ -16,7 +17,7 @@ final class Factory
 {
     public static function constructFastest(): HtmlCompressorInterface
     {
-        return new HtmlCompressor(new Patterns());
+        return new HtmlCompressor(new HtmlMin(), new Patterns());
     }
 
     public static function construct(): HtmlCompressorInterface
@@ -24,6 +25,7 @@ final class Factory
         $styleCompressor = CssFactory::construct();
 
         return new HtmlCompressor(
+            new HtmlMin(),
             new Patterns(
                 new LdJson(
                     new MMMJSCompressor()
@@ -49,6 +51,7 @@ final class Factory
         $styleCompressor = CssFactory::constructSmallest();
 
         return new HtmlCompressor(
+            new HtmlMin(),
             new Patterns(
                 new LdJson(
                     new MMMJSCompressor()

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -11,7 +11,6 @@ use WyriHaximus\HtmlCompress\Pattern\Style;
 use WyriHaximus\HtmlCompress\Pattern\StyleAttribute;
 use WyriHaximus\JsCompress\Compressor\MMMJSCompressor;
 use WyriHaximus\JsCompress\Factory as JsFactory;
-use const WyriHaximus\Constants\Boolean\TRUE_;
 
 final class Factory
 {
@@ -45,12 +44,9 @@ final class Factory
         );
     }
 
-    /**
-     * @param  bool $externalCompressors When set to false only use pure PHP compressors.
-     */
-    public static function constructSmallest(bool $externalCompressors = TRUE_): HtmlCompressorInterface
+    public static function constructSmallest(): HtmlCompressorInterface
     {
-        $styleCompressor = CssFactory::constructSmallest($externalCompressors);
+        $styleCompressor = CssFactory::constructSmallest();
 
         return new HtmlCompressor(
             new Patterns(
@@ -58,7 +54,7 @@ final class Factory
                     new MMMJSCompressor()
                 ),
                 new JavaScript(
-                    JsFactory::constructSmallest($externalCompressors)
+                    JsFactory::constructSmallest()
                 ),
                 new Script(
                     new ReturnCompressor()

--- a/src/HtmlCompressor.php
+++ b/src/HtmlCompressor.php
@@ -2,33 +2,32 @@
 
 namespace WyriHaximus\HtmlCompress;
 
-use voku\helper\HtmlMin as DefaultCompressor;
+use voku\helper\HtmlMin;
 
 final class HtmlCompressor implements HtmlCompressorInterface
 {
-    private DefaultCompressor $defaultCompressor;
+    private HtmlMin $htmlMin;
 
     private Patterns $patterns;
 
-    public function __construct(Patterns $patterns)
+    public function __construct(HtmlMin $htmlMin, Patterns $patterns)
     {
-        $this->defaultCompressor = new DefaultCompressor();
-        $this->patterns          = $patterns;
-        $this->compressor()->attachObserverToTheDomLoop($this->patterns); // Patterns $patters IS already a voku\helper\HtmlMinDomObserverInterface;
+        $this->htmlMin  = $htmlMin;
+        $this->patterns = $patterns;
+        $this->htmlMin->attachObserverToTheDomLoop($this->patterns);
     }
 
     public function compress(string $html): string
     {
-        return $this->compressor()->minify($html);
+        return $this->htmlMin->minify($html);
     }
 
-    public function compressor(): DefaultCompressor
+    public function withHtmlMin(HtmlMin $htmlMin): HtmlCompressorInterface
     {
-        return $this->defaultCompressor;
-    }
+        $clone          = clone $this;
+        $clone->htmlMin = $htmlMin;
+        $clone->htmlMin->attachObserverToTheDomLoop($clone->patterns);
 
-    public function patterns(): Patterns
-    {
-        return $this->patterns;
+        return $clone;
     }
 }

--- a/src/HtmlCompressorInterface.php
+++ b/src/HtmlCompressorInterface.php
@@ -2,8 +2,10 @@
 
 namespace WyriHaximus\HtmlCompress;
 
+use voku\helper\HtmlMin;
 use WyriHaximus\Compress\CompressorInterface;
 
 interface HtmlCompressorInterface extends CompressorInterface
 {
+    public function withHtmlMin(HtmlMin $htmlMin): self;
 }

--- a/tests/Compressor/HtmlCompressorTest.php
+++ b/tests/Compressor/HtmlCompressorTest.php
@@ -2,6 +2,7 @@
 
 namespace WyriHaximus\HtmlCompress\Tests\Compressor;
 
+use voku\helper\HtmlMin;
 use WyriHaximus\HtmlCompress\HtmlCompressor;
 use WyriHaximus\HtmlCompress\Patterns;
 use WyriHaximus\TestUtilities\TestCase;
@@ -40,7 +41,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testNewLinesTabsReturns($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 
@@ -83,7 +84,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testMultipleSpaces($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 
@@ -111,7 +112,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testSpaceAfterGt($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 
@@ -139,7 +140,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testSpaceBeforeLt($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 
@@ -167,7 +168,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testTrim($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 
@@ -190,7 +191,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testSpecialCharacterEncoding($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 
@@ -213,7 +214,7 @@ final class HtmlCompressorTest extends TestCase
      */
     public function testComments($input, $expected): void
     {
-        $actual = (new HtmlCompressor(new Patterns()))->compress($input);
+        $actual = (new HtmlCompressor(new HtmlMin(), new Patterns()))->compress($input);
         self::assertSame($expected, $actual);
     }
 }

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -2,6 +2,7 @@
 
 namespace WyriHaximus\HtmlCompress\Tests;
 
+use voku\helper\HtmlMin;
 use WyriHaximus\HtmlCompress\Factory;
 use WyriHaximus\HtmlCompress\HtmlCompressor;
 use WyriHaximus\TestUtilities\TestCase;
@@ -15,7 +16,7 @@ final class FactoryTest extends TestCase
 {
     public function testConstructFastest(): void
     {
-        $compressor = Factory::constructFastest();
+        $compressor = Factory::constructFastest()->withHtmlMin(new HtmlMin());
         self::assertInstanceOf(HtmlCompressor::class, $compressor);
 
         self::assertSame(
@@ -28,7 +29,7 @@ final class FactoryTest extends TestCase
 
     public function testConstruct(): void
     {
-        $compressor = Factory::construct();
+        $compressor = Factory::construct()->withHtmlMin(new HtmlMin());
         self::assertInstanceOf(HtmlCompressor::class, $compressor);
 
         self::assertSame(
@@ -39,35 +40,9 @@ final class FactoryTest extends TestCase
         );
     }
 
-    public function testConstructSmallestDefault(): void
+    public function testConstructSmallest(): void
     {
-        $compressor = Factory::constructSmallest();
-        self::assertInstanceOf(HtmlCompressor::class, $compressor);
-
-        self::assertSame(
-            safeFileGetContents(__DIR__ . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR . 'smallest' . DIRECTORY_SEPARATOR . 'out.html'),
-            $compressor->compress(
-                safeFileGetContents(__DIR__ . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR . 'smallest' . DIRECTORY_SEPARATOR . 'in.html')
-            )
-        );
-    }
-
-    public function testConstructSmallestNoExternal(): void
-    {
-        $compressor = Factory::constructSmallest(false);
-        self::assertInstanceOf(HtmlCompressor::class, $compressor);
-
-        self::assertSame(
-            safeFileGetContents(__DIR__ . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR . 'smallest' . DIRECTORY_SEPARATOR . 'out.html'),
-            $compressor->compress(
-                safeFileGetContents(__DIR__ . DIRECTORY_SEPARATOR . 'Factory' . DIRECTORY_SEPARATOR . 'smallest' . DIRECTORY_SEPARATOR . 'in.html')
-            )
-        );
-    }
-
-    public function testConstructSmallestExternal(): void
-    {
-        $compressor = Factory::constructSmallest(true);
+        $compressor = Factory::constructSmallest()->withHtmlMin(new HtmlMin());
         self::assertInstanceOf(HtmlCompressor::class, $compressor);
 
         self::assertSame(

--- a/tests/HtmlCompressorTest.php
+++ b/tests/HtmlCompressorTest.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace WyriHaximus\HtmlCompress\Tests;
+
+use voku\helper\HtmlMin;
+use WyriHaximus\HtmlCompress\Factory;
+use WyriHaximus\TestUtilities\TestCase;
+
+/**
+ * @internal
+ */
+final class HtmlCompressorTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function withHtmlMin(): void
+    {
+        $compressor = Factory::constructFastest();
+        $clone      = $compressor->withHtmlMin(new HtmlMin());
+
+        self::assertNotSame($compressor, $clone);
+    }
+}

--- a/tests/HtmlMinObserver/jscript-full-match/compressor.php
+++ b/tests/HtmlMinObserver/jscript-full-match/compressor.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use voku\helper\HtmlMin;
 use WyriHaximus\HtmlCompress\HtmlCompressor;
 use WyriHaximus\HtmlCompress\Pattern\JavaScript;
 use WyriHaximus\HtmlCompress\Patterns;
 use WyriHaximus\JsCompress\Compressor\MMMJSCompressor;
 
 return new HtmlCompressor(
+    new HtmlMin(),
     new Patterns(
         new JavaScript(
             new MMMJSCompressor()

--- a/tests/HtmlMinObserver/ld-json-full-match/compressor.php
+++ b/tests/HtmlMinObserver/ld-json-full-match/compressor.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use voku\helper\HtmlMin;
 use WyriHaximus\HtmlCompress\HtmlCompressor;
 use WyriHaximus\HtmlCompress\Pattern\LdJson;
 use WyriHaximus\HtmlCompress\Patterns;
 use WyriHaximus\JsCompress\Compressor\MMMJSCompressor;
 
 return new HtmlCompressor(
+    new HtmlMin(),
     new Patterns(
         new LdJson(
             new MMMJSCompressor()

--- a/tests/HtmlMinObserver/ld-json-not-matching-tag/compressor.php
+++ b/tests/HtmlMinObserver/ld-json-not-matching-tag/compressor.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use voku\helper\HtmlMin;
 use WyriHaximus\HtmlCompress\HtmlCompressor;
 use WyriHaximus\HtmlCompress\Pattern\LdJson;
 use WyriHaximus\HtmlCompress\Patterns;
 use WyriHaximus\JsCompress\Compressor\MMMJSCompressor;
 
 return new HtmlCompressor(
+    new HtmlMin(),
     new Patterns(
         new LdJson(
             new MMMJSCompressor()

--- a/tests/HtmlMinObserver/script-full-match/compressor.php
+++ b/tests/HtmlMinObserver/script-full-match/compressor.php
@@ -1,11 +1,13 @@
 <?php declare(strict_types=1);
 
+use voku\helper\HtmlMin;
 use WyriHaximus\HtmlCompress\HtmlCompressor;
 use WyriHaximus\HtmlCompress\Pattern\Script;
 use WyriHaximus\HtmlCompress\Patterns;
 use WyriHaximus\JsCompress\Compressor\MMMJSCompressor;
 
 return new HtmlCompressor(
+    new HtmlMin(),
     new Patterns(
         new Script(
             new MMMJSCompressor()

--- a/tests/HtmlMinObserverTest.php
+++ b/tests/HtmlMinObserverTest.php
@@ -41,7 +41,8 @@ final class HtmlMinObserverTest extends TestCase
         $in  = file_get_contents($dir . 'in.html');
         $out = file_get_contents($dir . 'out.html');
 
-        $result = (require $dir . 'compressor.php')->compress($in);
+        $compressor = require $dir . 'compressor.php';
+        $result     = $compressor->compress($in);
 
         self::assertSame($out, $result);
     }


### PR DESCRIPTION
Builds on top of @abuyoyo's #87 by reversing the pattern introduced there. The factory now accepts `HtmlMin` to allow changing configuration on it before injecting it, rather than changing after creating it as requested in #86