### PR TITLE
Update thecodingmachine/safe to 3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "thecodingmachine/safe": "^2.2",
+        "thecodingmachine/safe": "^2.2 || ^3.0",
         "voku/html-min": "^4.5.1",
         "voku/simple_html_dom": "^4.8.9",
         "wyrihaximus/compress": "^2.0",


### PR DESCRIPTION
thecodingmachine/safe issues deprecation warning on php8.4. Using the freshly released 3.0.0 fixes this issue.